### PR TITLE
nethserver-lightsquid.include: fix syntax for Duplicity 0.7

### DIFF
--- a/root/etc/backup-data.d/nethserver-lightsquid.include
+++ b/root/etc/backup-data.d/nethserver-lightsquid.include
@@ -1,1 +1,1 @@
-/var/lightsquid/
+/var/lightsquid


### PR DESCRIPTION
NethServer/dev#5101
