### PR TITLE
misspelled nethserver-lightsquid-save

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -23,7 +23,7 @@ use esmith::Build::CreateLinks  qw(:all);
 
 
 #--------------------------------------------------
-# actions for nethserver-ligthsquid-update event
+# actions for nethserver-lightsquid-update event
 #--------------------------------------------------
 
 my $event = "nethserver-lightsquid-update";
@@ -39,10 +39,10 @@ event_services($event, 'httpd' => 'reload');
 
 
 #--------------------------------------------------
-# actions for nethserver-ligthsquid-save event
+# actions for nethserver-lightsquid-save event
 #--------------------------------------------------
 
-$event = "nethserver-ligthsquid-save";
+$event = "nethserver-lightsquid-save";
 
 templates2events("/etc/lightsquid/lightsquid.cfg",  $event);
 


### PR DESCRIPTION
**Needs revision:**
[lightsquid misspelled](http://community.nethserver.org/t/ns7b2-lightsquid-diagnostic/4700) in nethserver-lig**th**squid-save

To apply for consistency, only if it does not break anything else (...it shouldn't)
