### PR TITLE
misspelled nethserver-lightsquid-save

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/Lightsquid/Settings.php
+++ b/root/usr/share/nethesis/NethServer/Module/Lightsquid/Settings.php
@@ -56,7 +56,7 @@ class Settings extends \Nethgui\Controller\AbstractController
 
     protected function onParametersSaved($changes)
     {
-        $this->getPlatform()->signalEvent('nethserver-ligthsquid-save');
+        $this->getPlatform()->signalEvent('nethserver-lightsquid-save');
     }
 
 


### PR DESCRIPTION
**Needs revision:**
[lightsquid misspelled](http://community.nethserver.org/t/ns7b2-lightsquid-diagnostic/4700) in nethserver-lig**th**squid-save

To apply for consistency, only if it does not break anything else (...it shouldn't)
